### PR TITLE
Fix docs mismatch

### DIFF
--- a/Sources/BeakCore/SwiftParser.swift
+++ b/Sources/BeakCore/SwiftParser.swift
@@ -16,8 +16,11 @@ public struct SwiftParser {
         // merge docs into structure
         var subStructure = structure.dictionary.substructure
         let swiftDocs = SwiftDocs(file: file, arguments: [])!
-        for (index, docStructure) in swiftDocs.docsDictionary.substructure.enumerated() {
-            subStructure[index][SwiftDocKey.documentationComment.rawValue] = docStructure[SwiftDocKey.documentationComment.rawValue]
+        
+        for docStructure in swiftDocs.docsDictionary.substructure {
+            if let index = subStructure.index(where: { $0.int(.nameOffset) == docStructure.int(.nameOffset) }) {
+                subStructure[index][SwiftDocKey.documentationComment.rawValue] = docStructure[SwiftDocKey.documentationComment.rawValue]
+            }
         }
         return try subStructure
             .filter { $0.kind == .functionFree && $0.accessibility == .public }


### PR DESCRIPTION
This fixes the issue where Beak incorrectly matches up doc comments with functions when global variables are declared above the functions. A basic example of this issue can be seen with a Beak file such as:

```swift
public let str = String(repeating: " ", count: 4)

/// This is the first func
public func firstFunc() {

}

/// This is the second func
public func secondFunc() {

}
```

Beak incorrectly matches docs with functions as such:

```shell
 > beak list
Functions:

  firstFunc: This is the second func
  secondFunc:

```

My implementation of the fix, while I believe it is the most clean and simple, is not necessarily the most performant (given the `index(where:)` call inside the for loop). I thought it best to leave it simple for now, but I'm happy to optimize if you think it's necessary