### PR TITLE
Use SwiftCLI

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -83,12 +83,12 @@
         }
       },
       {
-        "package": "SwiftPM",
-        "repositoryURL": "https://github.com/apple/swift-package-manager",
+        "package": "SwiftCLI",
+        "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "63a01220e93271dc3bf204b9e13dd1aeb2beefee",
-          "version": "0.2.0"
+          "revision": "5ff6ad3f547f83bd9a0b282be93330feb1fbf72d",
+          "version": "5.1.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/norio-nomura/Clang_C.git",
         "state": {
           "branch": null,
-          "revision": "90a9574276f0fd17f02f58979423c3fd4d73b59e",
-          "version": "1.0.2"
+          "revision": "7b7d3eed8080d14ba39c50e29fa8c7b051bcf969",
+          "version": "1.0.3"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "22800b0954c89344bb8c87f8ab93378076716fb7",
-          "version": "7.0.3"
+          "revision": "21f4fed2052cea480f5f1d2044d45aa25fdfb988",
+          "version": "7.1.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "0ff81f2c665b4381f526bd656f8708dd52a9ea2f",
-          "version": "1.2.0"
+          "revision": "3e3023569c8d4c4a0d000f58db765df53041117f",
+          "version": "1.3.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten",
         "state": {
           "branch": null,
-          "revision": "e06eb730499439ae32c5fbb6f72809ebec2371fd",
-          "version": "0.19.1"
+          "revision": "7c09176766d4bbc5da377ad857953fb49510a6aa",
+          "version": "0.21.0"
         }
       },
       {
@@ -87,17 +87,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "5ff6ad3f547f83bd9a0b282be93330feb1fbf72d",
-          "version": "5.1.0"
-        }
-      },
-      {
-        "package": "SwiftShell",
-        "repositoryURL": "https://github.com/kareman/SwiftShell.git",
-        "state": {
-          "branch": null,
-          "revision": "b9fd06798993153bc57cde10ee6c75ddc55c2dbd",
-          "version": "4.0.2"
+          "revision": "995f5966072bded933400bbe77ad24914f01d0c0",
+          "version": "5.1.1"
         }
       },
       {
@@ -105,8 +96,8 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "17d992beb3aaeda403fd35f8d5e70ab1a8124f35",
-          "version": "4.6.0"
+          "revision": "2211b35c2e0e8b08493f86ba52b26e530cabb751",
+          "version": "4.7.0"
         }
       },
       {
@@ -114,8 +105,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "95f45caf07472ec78223ebada45255086a85b01a",
-          "version": "0.5.0"
+          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
+          "version": "0.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
         .package(url: "https://github.com/kylef/PathKit.git", from: "0.8.0"),
         .package(url: "https://github.com/kylef/Spectre.git", from: "0.8.0"),
         .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.1.0"),
-        .package(url: "https://github.com/kareman/SwiftShell.git", from: "4.0.0"),
     ],
     targets: [
         .target(
@@ -27,7 +26,6 @@ let package = Package(
               "SourceKittenFramework",
               "PathKit",
               "SwiftCLI",
-              "SwiftShell",
             ]),
         .testTarget(name: "BeakTests", dependencies: [
           "BeakCore",

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/SourceKitten", from: "0.19.1"),
         .package(url: "https://github.com/kylef/PathKit.git", from: "0.8.0"),
         .package(url: "https://github.com/kylef/Spectre.git", from: "0.8.0"),
-        .package(url: "https://github.com/apple/swift-package-manager", from: "0.2.0"),
+        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "5.1.0"),
         .package(url: "https://github.com/kareman/SwiftShell.git", from: "4.0.0"),
     ],
     targets: [
@@ -26,7 +26,7 @@ let package = Package(
             dependencies: [
               "SourceKittenFramework",
               "PathKit",
-              "Utility",
+              "SwiftCLI",
               "SwiftShell",
             ]),
         .testTarget(name: "BeakTests", dependencies: [

--- a/Sources/Beak/main.swift
+++ b/Sources/Beak/main.swift
@@ -1,17 +1,5 @@
 import BeakCore
-import Foundation
-import PathKit
-import Utility
 
-do {
-    let options = BeakOptions()
-    let beak = Beak(options: options)
-    try beak.execute(arguments: Array(ProcessInfo.processInfo.arguments.dropFirst()))
-} catch {
-    if error._domain == NSCocoaErrorDomain {
-        print("⚠️  \(error.localizedDescription)")
-    } else {
-        print("⚠️  \(error)")
-    }
-    exit(1)
-}
+let options = BeakOptions()
+let beak = Beak(options: options)
+beak.execute()

--- a/Sources/Beak/main.swift
+++ b/Sources/Beak/main.swift
@@ -1,5 +1,7 @@
 import BeakCore
+import Foundation
 
 let options = BeakOptions()
 let beak = Beak(options: options)
-beak.execute()
+let result = beak.execute()
+exit(result)

--- a/Sources/BeakCore/Beak.swift
+++ b/Sources/BeakCore/Beak.swift
@@ -1,9 +1,5 @@
-import Basic
-import Foundation
 import PathKit
-import SourceKittenFramework
-import SwiftShell
-import Utility
+import SwiftCLI
 
 public struct BeakOptions {
 
@@ -25,31 +21,15 @@ public class Beak {
         self.options = options
     }
 
-    public func execute(arguments: [String]) throws {
-
-        let parser = ArgumentParser(commandName: "beak", usage: "[--path] [subcommand]", overview: "Beak can inspect and run functions in your swift scripts")
-        let versionArgument = parser.add(option: "--version", shortName: "-v", kind: Bool.self, usage: "Prints the current version of Beak")
-        _ = parser.add(option: "--path", shortName: "-p", kind: String.self, usage: "The path to a swift file. Defaults to beak.swift", completion: .filename)
-
-        let commands = [
-            "list": ListCommand(options: options, parentParser: parser),
-            "function": FunctionCommand(options: options, parentParser: parser),
-            "run": RunCommand(options: options, parentParser: parser),
-            "edit": EditCommand(options: options, parentParser: parser),
+    public func execute() -> Never {
+        let cli = CLI(name: "beak", version: version, description: "Beak can inspect and run functions in your swift scripts")
+        cli.globalOptions.append(_pathKey)
+        cli.commands = [
+            ListCommand(),
+            FunctionCommand(),
+            RunCommand(options: options),
+            EditCommand(options: options)
         ]
-
-        let parsedArguments = try parser.parse(arguments)
-
-        if let printVersion = parsedArguments.get(versionArgument), printVersion == true {
-            print(version)
-            return
-        }
-
-        if let subParser = parsedArguments.subparser(parser),
-            let command = commands[subParser] {
-            try command.execute(parsedArguments: parsedArguments)
-        } else {
-            parser.printUsage(on: stdoutStream)
-        }
+        cli.goAndExit()
     }
 }

--- a/Sources/BeakCore/Beak.swift
+++ b/Sources/BeakCore/Beak.swift
@@ -21,15 +21,19 @@ public class Beak {
         self.options = options
     }
 
-    public func execute() -> Never {
+    public func execute(arguments: [String]? = nil) -> Int32 {
         let cli = CLI(name: "beak", version: version, description: "Beak can inspect and run functions in your swift scripts")
-        cli.globalOptions.append(_pathKey)
+        cli.globalOptions.append(GlobalOptions.path)
         cli.commands = [
             ListCommand(),
             FunctionCommand(),
             RunCommand(options: options),
             EditCommand(options: options)
         ]
-        cli.goAndExit()
+        if let arguments = arguments {
+            return cli.go(with: arguments)
+        } else {
+            return cli.go()
+        }
     }
 }

--- a/Sources/BeakCore/BeakError.swift
+++ b/Sources/BeakCore/BeakError.swift
@@ -1,13 +1,14 @@
-import Foundation
 import SourceKittenFramework
+import SwiftCLI
 
-public enum BeakError: Error, CustomStringConvertible {
+public enum BeakError: ProcessError, CustomStringConvertible {
     case fileNotFound(String)
     case compileError(String)
     case invalidFunction(String)
     case missingRequiredParam(Function.Param)
     case parsingError(SwiftStructure)
-
+    case conversionError(Function.Param, String)
+    
     public var description: String {
         switch self {
         case let .fileNotFound(file): return "File not found: \(file)"
@@ -15,6 +16,16 @@ public enum BeakError: Error, CustomStringConvertible {
         case let .invalidFunction(function): return "Function \(function) was not found"
         case let .missingRequiredParam(param): return "Missing required param \(param.name)"
         case let .parsingError(structure): return "Could not parse Beak file structure:\n\(toJSON(structure))"
+        case let .conversionError(param, value): return "'\(value)' is not convertible to \(param.type.string) for argument \(param.name)"
         }
     }
+    
+    public var message: String? {
+        return "⚠️  \(description)"
+    }
+    
+    public var exitStatus: Int32 {
+        return 1
+    }
+    
 }

--- a/Sources/BeakCore/Commands/BeakCommand.swift
+++ b/Sources/BeakCore/Commands/BeakCommand.swift
@@ -1,7 +1,10 @@
 import PathKit
 import SwiftCLI
 
-let _pathKey = Key<String>("--path", "-p", description: "The path to a swift file. Defaults to beak.swift")
+struct GlobalOptions {
+    static let path = Key<String>("-p", "--path", description: "The path to a swift file. Defaults to beak.swift")
+    private init() {}
+}
 
 protocol BeakCommand: Command {
     func execute(path: Path, beakFile: BeakFile) throws
@@ -10,11 +13,11 @@ protocol BeakCommand: Command {
 extension BeakCommand {
     
     var path: Key<String> {
-        return _pathKey
+        return GlobalOptions.path
     }
     
     func execute() throws {
-        let path = Path(_pathKey.value ?? "beak.swift").normalize()
+        let path = Path(self.path.value ?? "beak.swift").normalize()
         let beakFile = try BeakFile(path: path)
         try execute(path: path, beakFile: beakFile)
     }

--- a/Sources/BeakCore/Commands/BeakCommand.swift
+++ b/Sources/BeakCore/Commands/BeakCommand.swift
@@ -1,25 +1,22 @@
-import Foundation
 import PathKit
-import Utility
+import SwiftCLI
 
-class BeakCommand {
+let _pathKey = Key<String>("--path", "-p", description: "The path to a swift file. Defaults to beak.swift")
 
-    let parser: ArgumentParser
-    let options: BeakOptions
-    let pathArgument: OptionArgument<String>
+protocol BeakCommand: Command {
+    func execute(path: Path, beakFile: BeakFile) throws
+}
 
-    init(options: BeakOptions, parentParser: ArgumentParser, name: String, description: String) {
-        self.options = options
-        parser = parentParser.add(subparser: name, overview: description)
-        pathArgument = parser.add(option: "--path", shortName: "-p", kind: String.self, usage: "The path to a swift file. Defaults to beak.swift", completion: .filename)
+extension BeakCommand {
+    
+    var path: Key<String> {
+        return _pathKey
     }
-
-    func execute(parsedArguments: ArgumentParser.Result) throws {
-        let path = Path(parsedArguments.get(pathArgument) ?? "beak.swift").normalize()
+    
+    func execute() throws {
+        let path = Path(_pathKey.value ?? "beak.swift").normalize()
         let beakFile = try BeakFile(path: path)
-        try execute(path: path, beakFile: beakFile, parsedArguments: parsedArguments)
+        try execute(path: path, beakFile: beakFile)
     }
-
-    func execute(path: Path, beakFile: BeakFile, parsedArguments: ArgumentParser.Result) throws {
-    }
+    
 }

--- a/Sources/BeakCore/Commands/EditCommand.swift
+++ b/Sources/BeakCore/Commands/EditCommand.swift
@@ -1,21 +1,18 @@
-import Foundation
-import Utility
 import PathKit
 import SwiftShell
 
 class EditCommand: BeakCommand {
+    
+    let name = "edit"
+    let shortDescription = "Edit the Swift file in an Xcode Project with imported dependencies"
+    
+    let options: BeakOptions
 
-    init(options: BeakOptions, parentParser: ArgumentParser) {
-        super.init(
-            options: options,
-            parentParser: parentParser,
-            name: "edit",
-            description: "Edit the Swift file in an Xcode Project with imported dependencies"
-        )
+    init(options: BeakOptions) {
+        self.options = options
     }
-
-    override func execute(path: Path, beakFile: BeakFile, parsedArguments: ArgumentParser.Result) throws {
-
+    
+    func execute(path: Path, beakFile: BeakFile) throws {
         let directory = path.absolute().parent()
 
         // create package

--- a/Sources/BeakCore/Commands/EditCommand.swift
+++ b/Sources/BeakCore/Commands/EditCommand.swift
@@ -24,8 +24,8 @@ class EditCommand: BeakCommand {
         do {
             _ = try capture("swift", arguments: ["package", "generate-xcodeproj"], directory: packagePath.string)
         } catch let error as CaptureError {
-            stdout <<< error.captured.rawStdout
-            stdout <<< error.captured.rawStderr
+            stderr <<< error.captured.rawStdout
+            stderr <<< error.captured.rawStderr
             throw error
         }
         stdout <<< "Generating project..."

--- a/Sources/BeakCore/Commands/FunctionCommand.swift
+++ b/Sources/BeakCore/Commands/FunctionCommand.swift
@@ -1,29 +1,20 @@
-import Foundation
 import PathKit
-import Utility
+import SwiftCLI
 
 class FunctionCommand: BeakCommand {
+    
+    let name = "function"
+    let shortDescription = "Info about a specific function"
+    
+    let functionName = Parameter()
 
-    var functionArgument: PositionalArgument<String>!
-
-    init(options: BeakOptions, parentParser: ArgumentParser) {
-        super.init(
-            options: options,
-            parentParser: parentParser,
-            name: "function",
-            description: "Info about a specific function"
-        )
-        functionArgument = parser.add(positional: "function", kind: String.self, optional: false, usage: "The function to get info about", completion: ShellCompletion.none)
-    }
-
-    override func execute(path: Path, beakFile: BeakFile, parsedArguments: ArgumentParser.Result) throws {
-        let functionName = parsedArguments.get(functionArgument)!
-        guard let function = beakFile.functions.first(where: { $0.name == functionName }) else {
-            throw BeakError.invalidFunction(functionName)
+    func execute(path: Path, beakFile: BeakFile) throws {
+        guard let function = beakFile.functions.first(where: { $0.name == functionName.value }) else {
+            throw BeakError.invalidFunction(functionName.value)
         }
-        let params = function.params.map { param in
-            "\(param.name): \(param.optionalType)\(param.defaultValue != nil ? " = \(param.defaultValue!)" : "")\(param.description != nil ? "  - \(param.description!)" : "")"
+        stdout <<< "\(function.name):\(function.docsDescription != nil ? " \(function.docsDescription!)" : "")"
+        function.params.forEach { param in
+            stdout <<< "  \(param.name): \(param.optionalType)\(param.defaultValue != nil ? " = \(param.defaultValue!)" : "")\(param.description != nil ? "  - \(param.description!)" : "")"
         }
-        print("\(function.name):\(function.docsDescription != nil ? " \(function.docsDescription!)" : "")\n  \(params.joined(separator: "\n  "))")
     }
 }

--- a/Sources/BeakCore/Commands/ListCommand.swift
+++ b/Sources/BeakCore/Commands/ListCommand.swift
@@ -1,22 +1,17 @@
-import Foundation
-import Utility
 import PathKit
+import SwiftCLI
 
 class ListCommand: BeakCommand {
 
-    init(options: BeakOptions, parentParser: ArgumentParser) {
-        super.init(
-            options: options,
-            parentParser: parentParser,
-            name: "list",
-            description: "Lists all functions"
-        )
-    }
+    let name = "list"
+    let shortDescription = "Lists all functions"
 
-    override func execute(path: Path, beakFile: BeakFile, parsedArguments: ArgumentParser.Result) throws {
-        let functions = beakFile.functions.map { function in
-            "\(function.name): \(function.docsDescription ?? "")"
+    func execute(path: Path, beakFile: BeakFile) throws {
+        stdout <<< "Functions:"
+        stdout <<< ""
+        beakFile.functions.forEach { function in
+            stdout <<< "  \(function.name): \(function.docsDescription ?? "")"
         }
-        print("Functions:\n\n  \(functions.joined(separator: "\n  "))\n")
+        stdout <<< ""
     }
 }

--- a/Sources/BeakCore/Commands/RunCommand.swift
+++ b/Sources/BeakCore/Commands/RunCommand.swift
@@ -36,8 +36,8 @@ class RunCommand: BeakCommand {
         do {
             _ = try capture("swift", arguments: ["build", "--disable-sandbox"], directory: packagePath.string)
         } catch let error as CaptureError {
-            stdout <<< error.captured.rawStdout
-            stdout <<< error.captured.rawStderr
+            stderr <<< error.captured.rawStdout
+            stderr <<< error.captured.rawStderr
             throw error
         }
 

--- a/Sources/BeakCore/Commands/RunCommand.swift
+++ b/Sources/BeakCore/Commands/RunCommand.swift
@@ -1,36 +1,30 @@
-import Foundation
 import PathKit
 import SwiftShell
-import Utility
+import SwiftCLI
 
 class RunCommand: BeakCommand {
 
-    var functionArgument: PositionalArgument<[String]>!
+    let name = "run"
+    let shortDescription = "Run a function"
 
-    init(options: BeakOptions, parentParser: ArgumentParser) {
-        super.init(
-            options: options,
-            parentParser: parentParser,
-            name: "run",
-            description: "Run a function"
-        )
-        functionArgument = parser.add(positional: "function", kind: [String].self, optional: true, strategy: .remaining, usage: "The function to run", completion: ShellCompletion.none)
+    let function = OptionalParameter()
+    let functionArgs = OptionalCollectedParameter()
+    
+    let options: BeakOptions
+
+    init(options: BeakOptions) {
+        self.options = options
     }
 
-    override func execute(path: Path, beakFile: BeakFile, parsedArguments: ArgumentParser.Result) throws {
-        var functionArguments = parsedArguments.get(functionArgument) ?? []
-
+    func execute(path: Path, beakFile: BeakFile) throws {
         var functionCall: String?
 
         // parse function call
-        if !functionArguments.isEmpty {
-            let functionName = functionArguments[0]
-            functionArguments = Array(functionArguments.dropFirst())
-
+        if let functionName = function.value {
             guard let function = beakFile.functions.first(where: { $0.name == functionName }) else {
                 throw BeakError.invalidFunction(functionName)
             }
-            functionCall = try FunctionParser.getFunctionCall(function: function, arguments: functionArguments)
+            functionCall = try FunctionParser.getFunctionCall(function: function, arguments: functionArgs.value)
         }
 
         // create package

--- a/Sources/BeakCore/Commands/RunCommand.swift
+++ b/Sources/BeakCore/Commands/RunCommand.swift
@@ -1,5 +1,4 @@
 import PathKit
-import SwiftShell
 import SwiftCLI
 
 class RunCommand: BeakCommand {
@@ -34,16 +33,15 @@ class RunCommand: BeakCommand {
         try packageManager.write(functionCall: functionCall)
 
         // build package
-        var packageContext = CustomContext(main)
-        packageContext.currentdirectory = packagePath.string
-        let buildOutput = packageContext.run(bash: "swift build --disable-sandbox")
-        if let error = buildOutput.error {
-            print(buildOutput.stdout)
-            print(buildOutput.stderror)
+        do {
+            _ = try capture("swift", arguments: ["build", "--disable-sandbox"], directory: packagePath.string)
+        } catch let error as CaptureError {
+            stdout <<< error.captured.rawStdout
+            stdout <<< error.captured.rawStderr
             throw error
         }
 
         // run package
-        try runAndPrint(bash: "\(packagePath.string)/.build/debug/\(options.packageName)")
+        try Task.execvp("\(packagePath.string)/.build/debug/\(options.packageName)", arguments: [])
     }
 }

--- a/Sources/BeakCore/FunctionParser.swift
+++ b/Sources/BeakCore/FunctionParser.swift
@@ -23,19 +23,19 @@ public struct FunctionParser {
         var parsedParams: [String] = []
         var args = arguments
         for param in function.params {
-            let paramValue: String?
+            let possibleValue: String?
             if param.unnamed {
-                paramValue = args.isEmpty ? nil : args.removeFirst()
+                possibleValue = args.isEmpty ? nil : args.removeFirst()
             } else {
                 if let index = args.index(where: { $0 == "--\(param.name)" }), index + 1 < args.count {
                     args.remove(at: index)
-                    paramValue = args.remove(at: index)
+                    possibleValue = args.remove(at: index)
                 } else {
-                    paramValue = nil
+                    possibleValue = nil
                 }
             }
             
-            guard let rawValue = paramValue else {
+            guard var value = possibleValue else {
                 if param.required {
                     throw BeakError.missingRequiredParam(param)
                 } else {
@@ -43,22 +43,20 @@ public struct FunctionParser {
                 }
             }
             
-            let value: String
             switch param.type {
             case .bool:
-                guard let converted = Bool.convert(from: rawValue) else {
-                    throw BeakError.conversionError(param, rawValue)
+                guard let converted = Bool.convert(from: value) else {
+                    throw BeakError.conversionError(param, value)
                 }
                 value = converted.description
             case .int:
-                guard let converted = Int.convert(from: rawValue) else {
-                    throw BeakError.conversionError(param, rawValue)
+                guard let converted = Int.convert(from: value) else {
+                    throw BeakError.conversionError(param, value)
                 }
                 value = converted.description
             case .string:
-                value = rawValue.quoted
-            case .other:
-                value = rawValue
+                value = value.quoted
+            case .other: break
             }
             
             if param.unnamed {

--- a/Sources/BeakCore/FunctionParser.swift
+++ b/Sources/BeakCore/FunctionParser.swift
@@ -43,20 +43,26 @@ public struct FunctionParser {
                 }
             }
             
-            switch param.type {
-            case .bool:
-                guard let converted = Bool.convert(from: value) else {
+            if value == "nil" {
+                if !param.optional {
                     throw BeakError.conversionError(param, value)
                 }
-                value = converted.description
-            case .int:
-                guard let converted = Int.convert(from: value) else {
-                    throw BeakError.conversionError(param, value)
+            } else {
+                switch param.type {
+                case .bool:
+                    guard let converted = Bool.convert(from: value) else {
+                        throw BeakError.conversionError(param, value)
+                    }
+                    value = converted.description
+                case .int:
+                    guard let converted = Int.convert(from: value) else {
+                        throw BeakError.conversionError(param, value)
+                    }
+                    value = converted.description
+                case .string:
+                    value = value.quoted
+                case .other: break
                 }
-                value = converted.description
-            case .string:
-                value = value.quoted
-            case .other: break
             }
             
             if param.unnamed {

--- a/Sources/BeakCore/SwiftParser.swift
+++ b/Sources/BeakCore/SwiftParser.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SourceKittenFramework
-import Utility
 
 public struct SwiftParser {
 
@@ -36,14 +35,14 @@ public struct SwiftParser {
         var description: String?
 
         if let docs = docs {
-            let docsSplit = docs.split(around: "- Parameters:")
-            description = docsSplit.0.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let paramDocs = docsSplit.1 {
+            if let split = docs.range(of: "- Parameters:") {
+                description = String(docs.prefix(upTo: split.lowerBound)).trimmingCharacters(in: .whitespacesAndNewlines)
+                
+                let paramDocs = String(docs.suffix(from: split.upperBound))
                 let regEx = try! NSRegularExpression(pattern: "  - (.*?): (.*?)$", options: [.anchorsMatchLines])
                 let matches = regEx.matches(in: paramDocs, options: [], range: NSRange(location: 0, length: paramDocs.count))
 
                 for match in matches {
-
                     let nameRange = match.range(at: 1)
                     let name = paramDocs
                         .substring(start: nameRange.location, length: nameRange.length)
@@ -56,9 +55,9 @@ public struct SwiftParser {
 
                     paramDescriptions[name] = description
                 }
+            } else {
+                description = docs.trimmingCharacters(in: .whitespacesAndNewlines)
             }
-        } else {
-            description = nil
         }
         let name = String(functionSignature.split(separator: "(").first!)
         let publicNames = functionSignature.split(separator: "(").last!.split(separator: ":")


### PR DESCRIPTION
This is a possible fix to #28. In most places I tried to make the fewest changes possible so that this PR wasn't too unwieldy. Most changes are relatively straight forward, but `FunctionParser.getParams` needed to be largely rewritten.

Bugs fixed:
- SIGINT will now be forwarded to subprocesses
- Input will now be handled correctly in subprocesses launched with `beak run`
- `nil` is now a valid value for optional function parameters

Public API changed:
- `public func execute(arguments: [String]) throws` -> `public func execute(arguments: [String]? = nil) -> Int32`

I'd also to like to re-emphasize that I am not trying to force `SwiftCLI` on this project in any way, this is just one solution to #28. If you decide to not use `SwiftCLI` I'd be happy to open a new PR which fixes the SIGINT problem with `SwiftShell`!