### PR TITLE
Update to Swift 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,15 @@
 version: 2
 jobs:
-  macOS_swift_4.1:
+  macOS_swift_5.0:
     macos:
-      xcode: "9.3.0"
+      xcode: "10.2.0"
     steps:
       - checkout
       - run: swift build
       - run: swift test
-  linux_swift_4.1:
+  linux_swift_5.0:
     docker:
-      - image: norionomura/swift:41
+      - image: norionomura/swift:50
     steps:
       - checkout
       - run: swift build
@@ -18,5 +18,5 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - macOS_swift_4.1
-      - linux_swift_4.1
+      - macOS_swift_5.0
+      - linux_swift_5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,4 +19,6 @@ workflows:
   workflow:
     jobs:
       - macOS_swift_5.0
-      - linux_swift_5.0
+      # disable Linux for now
+      #- linux_swift_5.0
+      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+### Changed:
+- Updated to Swift 5 and dropped Swift 4.2 #44 @yonaskolb
+
 ## 0.4.0
 
 ### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Clang_C",
-        "repositoryURL": "https://github.com/norio-nomura/Clang_C.git",
-        "state": {
-          "branch": null,
-          "revision": "7b7d3eed8080d14ba39c50e29fa8c7b051bcf969",
-          "version": "1.0.3"
-        }
-      },
-      {
         "package": "Commandant",
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
           "branch": null,
-          "revision": "7f29606ec3a2054a601f0e72f562a104dbc1a11a",
-          "version": "0.13.0"
+          "revision": "07cad52573bad19d95844035bf0b25acddf6b0f6",
+          "version": "0.15.0"
         }
       },
       {
@@ -24,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "21f4fed2052cea480f5f1d2044d45aa25fdfb988",
-          "version": "7.1.1"
+          "revision": "e9d769113660769a4d9dd3afb855562c0b7ae7b0",
+          "version": "7.3.4"
         }
       },
       {
@@ -33,8 +24,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "fa81fa9e3a9f59645159c4ea45c0c46ee6558f71",
-          "version": "0.9.1"
+          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
+          "version": "0.9.2"
         }
       },
       {
@@ -42,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "3e3023569c8d4c4a0d000f58db765df53041117f",
-          "version": "1.3.0"
+          "revision": "f2b5a06440ea87eba1a167cab37bf6496646c52e",
+          "version": "1.3.4"
         }
       },
       {
@@ -51,17 +42,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "7477584259bfce2560a19e06ad9f71db441fff11",
-          "version": "3.2.4"
-        }
-      },
-      {
-        "package": "SourceKit",
-        "repositoryURL": "https://github.com/norio-nomura/SourceKit.git",
-        "state": {
-          "branch": null,
-          "revision": "18eaa67ca44443bbe39646916792b9f0c98dbaa1",
-          "version": "1.0.1"
+          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
+          "version": "4.1.0"
         }
       },
       {
@@ -69,8 +51,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten",
         "state": {
           "branch": null,
-          "revision": "7c09176766d4bbc5da377ad857953fb49510a6aa",
-          "version": "0.21.0"
+          "revision": "176f04295a09324673245d8ec0afcce21ace8722",
+          "version": "0.22.0"
         }
       },
       {
@@ -78,8 +60,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "e34d5687e1e9d865e3527dd58bc2f7464ef6d936",
-          "version": "0.8.0"
+          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
+          "version": "0.9.0"
         }
       },
       {
@@ -87,8 +69,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
         "state": {
           "branch": null,
-          "revision": "995f5966072bded933400bbe77ad24914f01d0c0",
-          "version": "5.1.1"
+          "revision": "5318c37d3cacc8780f50b87a8840a6774320ebdf",
+          "version": "5.2.2"
         }
       },
       {
@@ -96,8 +78,8 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "2211b35c2e0e8b08493f86ba52b26e530cabb751",
-          "version": "4.7.0"
+          "revision": "0d6bb315528888edde0dafe93564f074669c44e9",
+          "version": "4.8.0"
         }
       },
       {
@@ -105,8 +87,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
-          "version": "0.7.0"
+          "revision": "26ab35f50ea891e8edefcc9d975db2f6b67e1d68",
+          "version": "1.0.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By default Beak looks for a file called `beak.swift` in your current directory, 
 This repo itself has a Beak file for running build scripts.
 
 ## Installing
-Make sure Xcode 9+ is installed first.
+Make sure Xcode 10.2+ is installed first.
 
 ### [Mint](https://github.com/yonaskolb/mint) 🌱
 ```sh

--- a/Sources/BeakCore/Function.swift
+++ b/Sources/BeakCore/Function.swift
@@ -49,7 +49,7 @@ public struct Function: Equatable, CustomStringConvertible {
             case other(String)
 
             public init(stringLiteral value: String) {
-                self.init(stringLiteral: value)
+                self.init(string: value)
             }
 
             public init(string: String) {

--- a/Sources/BeakCore/FunctionParser.swift
+++ b/Sources/BeakCore/FunctionParser.swift
@@ -27,7 +27,7 @@ public struct FunctionParser {
             if param.unnamed {
                 possibleValue = args.isEmpty ? nil : args.removeFirst()
             } else {
-                if let index = args.index(where: { $0 == "--\(param.name)" }), index + 1 < args.count {
+                if let index = args.firstIndex(where: { $0 == "--\(param.name)" }), index + 1 < args.count {
                     args.remove(at: index)
                     possibleValue = args.remove(at: index)
                 } else {

--- a/Sources/BeakCore/SwiftParser.swift
+++ b/Sources/BeakCore/SwiftParser.swift
@@ -17,7 +17,7 @@ public struct SwiftParser {
         let swiftDocs = SwiftDocs(file: file, arguments: [])!
 
         for docStructure in swiftDocs.docsDictionary.substructure {
-            if let index = subStructure.index(where: { $0.int(.nameOffset) == docStructure.int(.nameOffset) }) {
+            if let index = subStructure.firstIndex(where: { $0.int(.nameOffset) == docStructure.int(.nameOffset) }) {
                 subStructure[index][SwiftDocKey.documentationComment.rawValue] = docStructure[SwiftDocKey.documentationComment.rawValue]
             }
         }

--- a/beak.swift
+++ b/beak.swift
@@ -23,7 +23,7 @@ public func formatCode() throws {
 ///   - directory: The directory to install beak
 public func install(directory: String = "/usr/local/bin") throws {
     print("🐦  Building Beak...")
-    let output = run(bash: "swift build --disable-sandbox -c release -Xswiftc -static-stdlib")
+    let output = run(bash: "swift build --disable-sandbox -c release")
     if let error = output.error {
         print("Couldn't build:\n\(error)")
         return


### PR DESCRIPTION
This updates to Swift 5 and drops Swift 4.2
Fixes #43 

Had to disable Linux tests due to the following error:
```
<unknown>:0: error: unable to execute command: Killed
<unknown>:0: error: compile command failed due to signal 9 (use -v to see invocation)
```