### PR TITLE
Ensure edited file's attributes remain intact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Next Version
+- Fixed edit command removing file attributes #46 @maxchuquimia
 
 ## 0.5.1
 

--- a/Sources/BeakCLI/Commands/EditCommand.swift
+++ b/Sources/BeakCLI/Commands/EditCommand.swift
@@ -1,6 +1,7 @@
 import PathKit
 import SwiftCLI
 import BeakCore
+import Foundation
 
 class EditCommand: BeakCommand {
 
@@ -39,8 +40,9 @@ class EditCommand: BeakCommand {
 
         let line = readLine()
         if line?.lowercased() == "c" {
+            let attributes = try FileManager.default.attributesOfItem(atPath: path.string)
             try path.delete()
-            try packageManager.mainFilePath.copy(path)
+            try FileManager.default.createFile(atPath: path.string, contents: packageManager.mainFilePath.read(), attributes: attributes)
             stdout <<< "Copied edited file back to \(path.string)"
         } else {
             stdout <<< "Changes not copied back to \(path.string)"


### PR DESCRIPTION
I have a case where I create a Swift/Beak script and run `chmod +x` on it so that I can use it as a normal command (with `#!/usr/bin/env beak run --path` too)

I found that if I `beak edit -p` the file (amazing, by the way), upon committing the changes the file is no longer executable so I need to `chmod +x` again.

I've made this change and it works, however please let me know if there's a better, more PathKit-y way that you would do this ☺️ 